### PR TITLE
bump version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        PYTHON_VERSION: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        PYTHON_VERSION: ["3.7", "3.8", "3.9", "3.10"]
 
     name: Build
     runs-on: ubuntu-latest

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        PYTHON_VERSION: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        PYTHON_VERSION: ["3.7", "3.8", "3.9", "3.10"]
 
     name: Check
     runs-on: ubuntu-latest

--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,7 @@ setuptools.setup(
     license="Apache Software License",
     name="pretty",
     packages=packages,
-    python_requires=">=3.6.0",
+    python_requires=">=3.7.0",
     url="https://github.com/ShineyDev/pretty",
     version=version,
 )


### PR DESCRIPTION
The [pretty@meta-python-36-eol branch](https://github.com/ShineyDev/pretty/tree/meta-python-36-eol) bumps the Python version requirement from 36 to 37.